### PR TITLE
add check_elasticsearch test

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ Verify a static file is reachable
 
 - `filename` (`str`):  static file to verify
 
+---
+
+```python
+def check_elasticsearch(settings)
+```
+
+- `settings` (`dict`):  Parameter that will be passed to Elasticsearch()
+
+Ping ElasticSearch to check it is alive. Needs `elasticsearch` package to be installed.
+
 ## Management Command
 
 In addition to the view, the configured healthchecks can also be run via a management command with `manage.py healthcheck`. This will exit with an error code if all the healthchecks do not pass.

--- a/django_alive/checks.py
+++ b/django_alive/checks.py
@@ -63,6 +63,25 @@ def check_cache(key="django-alive", cache="default"):
         raise HealthcheckFailure("cache error")
 
 
+def check_elasticsearch(settings={}):
+    # type: (dict) -> None
+    """
+    Ping the Elasticsearch server to verify it's reachable
+
+    :param dict settings: Elasticsearch settings
+    :return None:
+    """
+    try:
+        from elasticsearch import Elasticsearch
+        ping = Elasticsearch(settings).ping()
+    except Exception:
+        log.exception("elasticsearch connection failed")
+        raise HealthcheckFailure("elasticsearch exception")
+    if not ping:
+        log.error("elasticsearch ping failed")
+        raise HealthcheckFailure("elasticsearch error")
+
+
 def check_migrations(alias=None):
     # type: (Optional[str]) -> None
     """


### PR DESCRIPTION
Add simple check for ElasticSearch.
It requires `elasticsearch` package to be installed to perform this test, but if the test is not active, it should not be required.