### PR TITLE
 Add a GitHub Action To Auto-Publish On Tag Pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,102 @@
+name: Publish to PyPI
+on:
+  push:
+    branches: [main, test-publish]
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    
+    # If the event that triggered this workflow is a push of a tag, then build with
+    # the version of that tag.
+    - name: Build a binary wheel and a source tarball for tag
+      run: BUILD_VERSION=${{ github.ref_name }} python3 -m build
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # The event that trigged this workflow is not a tag, so build without specifying the version.
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+      if: "!startsWith(github.ref, 'refs/tags/')"
+    
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  pypi-publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [build]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-alive
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - pypi-publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --generate-notes
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------
 
 - Add GitHub Action for running tests against supported versions
+- Release from GitHub Actions
 
 
 1.2.1 (2021-07-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-1.2.2 (unreleased)
+1.2.3 (unreleased)
+------------------
+
+- Nothing changed yet.
+
+
+1.2.2 (2024-08-14)
 ------------------
 
 - Add GitHub Action for running tests against supported versions

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
+import os
 import setuptools
-setuptools.setup()
+setuptools.setup(version=os.environ.get("BUILD_VERSION"))


### PR DESCRIPTION
Following the [instructions from python.org](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/), this pull request adds a GitHub Action that:
 - builds on all pull requests and pushes to the `main` branch
 - releases on all tag pushes to the `main` branch

Note: in testing this code, I've already released version 4.0.3. See:
 - the GitHub Action run: https://github.com/lincolnloop/django-alive/actions/runs/
 - the release on PyPI: https://pypi.org/project/django-alive/1.2.2/
 - the release on GitHub: https://github.com/lincolnloop/django-alive/releases/tag/1.2.2
